### PR TITLE
Add careers page and update contact and footer

### DIFF
--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Careers at Kenroz',
+  description: 'Join the Kenroz team and help build innovative technology solutions.',
+};
+
+export default function CareersPage() {
+  return (
+    <div className="bg-gradient-to-br from-[#df2a33]/10 via-white to-[#9B2730]/10 min-h-screen py-16">
+      <div className="container mx-auto px-4 max-w-4xl">
+        <header className="text-center mb-16">
+          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-[#9B2730] via-[#df2a33] to-black bg-clip-text text-transparent">
+            Careers
+          </h1>
+          <p className="text-lg text-gray-700 max-w-2xl mx-auto">
+            We&apos;re always looking for passionate people to join our growing team. If you love creating
+            impactful digital experiences, Kenroz is the place for you.
+          </p>
+        </header>
+
+        <section className="space-y-8">
+          <div className="p-6 bg-white rounded-xl shadow-lg hover:shadow-xl transition-all">
+            <h2 className="text-2xl font-bold mb-2">Junior Frontend Developer, React</h2>
+            <p className="text-gray-700 mb-4">
+              <strong>Experience:</strong> No minimum experience required
+            </p>
+            <p className="text-gray-700 mb-4">
+              <strong>Requirements:</strong> Solid knowledge of React and at least two personal projects showcasing your skills.
+            </p>
+            <p className="text-gray-700 mb-4">
+              <strong>Positions Open:</strong> Multiple
+            </p>
+            <p className="text-gray-700">
+              To apply, send your resume and project links to <a href="mailto:hr@kenroz.com" className="text-[#df2a33] font-semibold">hr@kenroz.com</a>.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -68,11 +68,7 @@ export default function ContactPage() {
           </header>
 
           {/* Enhanced Contact Form */}
-          <EnhancedContactForm
-            title="Let's Start a Conversation"
-            description="Tell us about your project and we'll get back to you within 24 hours with a detailed proposal."
-            showContactInfo={true}
-          />
+          <EnhancedContactForm showContactInfo={true} />
 
           {/* Additional Contact Information */}
           <section className="mt-20 text-center">
@@ -80,7 +76,7 @@ export default function ContactPage() {
               Why Choose Kenroz?
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
-              <div className="p-6 bg-white rounded-xl shadow-lg">
+              <div className="p-6 bg-white rounded-xl shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl">
                 <div className="w-12 h-12 bg-gradient-to-br from-[#df2a33]/20 to-[#9B2730]/20 rounded-full flex items-center justify-center mx-auto mb-4">
                   <span className="text-2xl">⚡</span>
                 </div>
@@ -89,7 +85,7 @@ export default function ContactPage() {
                   We respond to all inquiries within 24 hours during business days
                 </p>
               </div>
-              <div className="p-6 bg-white rounded-xl shadow-lg">
+              <div className="p-6 bg-white rounded-xl shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl">
                 <div className="w-12 h-12 bg-gradient-to-br from-[#df2a33]/20 to-[#9B2730]/20 rounded-full flex items-center justify-center mx-auto mb-4">
                   <span className="text-2xl">🎯</span>
                 </div>
@@ -98,7 +94,7 @@ export default function ContactPage() {
                   Free initial consultation to understand your specific needs
                 </p>
               </div>
-              <div className="p-6 bg-white rounded-xl shadow-lg">
+              <div className="p-6 bg-white rounded-xl shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl">
                 <div className="w-12 h-12 bg-gradient-to-br from-[#df2a33]/20 to-[#9B2730]/20 rounded-full flex items-center justify-center mx-auto mb-4">
                   <span className="text-2xl">🤝</span>
                 </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -74,7 +74,7 @@ export default function Navbar(): JSX.Element {
 
           <div className="flex gap-5 items-center">
             <ButtonLink
-              href="/contact-us?p=hire"
+              href="/careers"
               className="hidden lg:inline-flex items-center font-semibold text-sm whitespace-nowrap px-8 py-3 border border-solid text-[#df2a33] transition-colors hover:bg-gradient-to-r hover:from-[#df2a33] hover:to-[#9B2730]  border-[#df2a33] bg-transparent  hover:text-white rounded-full"
             >
               Careers
@@ -133,6 +133,11 @@ export default function Navbar(): JSX.Element {
                 <MobileNavItem
                   href="/products"
                   text="PRODUCTS"
+                  onClick={() => setIsMenuOpen(false)}
+                />
+                <MobileNavItem
+                  href="/careers"
+                  text="CAREERS"
                   onClick={() => setIsMenuOpen(false)}
                 />
                 <MobileNavItem

--- a/src/components/contact/EnhancedContactForm.tsx
+++ b/src/components/contact/EnhancedContactForm.tsx
@@ -21,15 +21,11 @@ interface FormErrors {
 }
 
 interface EnhancedContactFormProps {
-  title?: string;
-  description?: string;
   className?: string;
   showContactInfo?: boolean;
 }
 
 export default function EnhancedContactForm({
-  title = "Get in Touch",
-  description = "Have questions? We'd love to hear from you. Send us a message and we'll response as soon as possible.",
   className = "",
   showContactInfo = true,
 }: EnhancedContactFormProps) {
@@ -324,7 +320,12 @@ export default function EnhancedContactForm({
 
         {/* Contact Information */}
         {showContactInfo && (
-          <LocationSwitcher title={title} description={description} />
+          <div className="bg-gradient-to-br from-[#9B2730] to-[#df2a33] rounded-xl p-8 text-white">
+            <LocationSwitcher
+              title="Our Offices"
+              description="Choose your region to get in touch"
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -77,7 +77,7 @@ export default function Footer() {
                 <li key={link}>
                   <a
                     href={`#${link.toLowerCase().replace(" ", "")}`}
-                    className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 hover:translate-x-1 transform inline-block text-sm"
+                    className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 hover:translate-x-1 transform inline-block text-base"
                     onClick={(e) => {
                       e.preventDefault();
                       const element = document.getElementById(
@@ -100,7 +100,7 @@ export default function Footer() {
                 <li key={service}>
                   <a
                     href="#services"
-                    className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 hover:translate-x-1 transform inline-block text-sm"
+                    className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 hover:translate-x-1 transform inline-block text-base"
                     onClick={(e) => {
                       e.preventDefault();
                       document
@@ -115,25 +115,25 @@ export default function Footer() {
             </ul>
           </div>
         </div>
-        <div className="border-t border-gray-700 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <div className="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-6">
-            <p className="text-gray-400 text-sm">
-              © {new Date().getFullYear()} Kenroz. All rights reserved. Made
-              with ❤️ in Hyderabad
-            </p>
-            <div className="flex space-x-4">
-              {legalLinks.map((legal) => (
-                <a
-                  key={legal}
-                  href="#"
-                  className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 text-xs"
-                  onClick={(e) => e.preventDefault()}
-                >
-                  {legal}
-                </a>
-              ))}
-            </div>
+        <div className="mt-12 mb-8 flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-6">
+          <p className="text-gray-400 text-sm">
+            © {new Date().getFullYear()} Kenroz. All rights reserved. Made
+            with ❤️ in Hyderabad
+          </p>
+          <div className="flex space-x-4">
+            {legalLinks.map((legal) => (
+              <a
+                key={legal}
+                href="#"
+                className="text-gray-400 hover:text-[#df2a33] transition-colors duration-300 text-sm"
+                onClick={(e) => e.preventDefault()}
+              >
+                {legal}
+              </a>
+            ))}
           </div>
+        </div>
+        <div className="border-t border-gray-700 pt-8 flex flex-col md:flex-row justify-between items-center">
           <div className="flex space-x-4 mt-4 md:mt-0">
             {socials.map(({ icon: Icon, href }, index) => (
               <a


### PR DESCRIPTION
## Summary
- add careers page with job listing and application instructions
- expose careers link in navbar
- add country tabs and hover effects to contact page
- enlarge footer links and reposition copyright

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in SEO utilities)


------
https://chatgpt.com/codex/tasks/task_e_68989e007554832ea42663d823bdf012